### PR TITLE
POC of using async strategy for Google Analytics script

### DIFF
--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -176,9 +176,10 @@ class Jetpack_Google_Analytics_Legacy {
 				),
 			);
 		}
-		
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
 		wp_enqueue_script( 'jetpack-google-analytics', "https://www.googletagmanager.com/gtag/js?id={$tracking_id}", array(), null, array( 'strategy' => 'async' ) );
-		
+
 		?>
 		ob_start();
 		<script>
@@ -196,7 +197,7 @@ class Jetpack_Google_Analytics_Legacy {
 		</script>
 		<?php
 		$data_later_js = str_replace( array( '<script>', '</script>' ), '', ob_get_clean() );
-		wp_add_inline_script( 
+		wp_add_inline_script(
 			'jetpack-google-analytics',
 			$data_later_js,
 			'after'

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -182,7 +182,6 @@ class Jetpack_Google_Analytics_Legacy {
 		?>
 		ob_start();
 		<script>
-			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
 			gtag( 'js', new Date() );
 			gtag( 'config', <?php echo wp_json_encode( $tracking_id ); ?> );

--- a/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
+++ b/projects/plugins/jetpack/modules/google-analytics/classes/wp-google-analytics-legacy.php
@@ -25,7 +25,7 @@ class Jetpack_Google_Analytics_Legacy {
 	public function __construct() {
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_anonymize_ip' ) );
 		add_filter( 'jetpack_wga_classic_custom_vars', array( $this, 'jetpack_wga_classic_track_purchases' ) );
-		add_action( 'wp_head', array( $this, 'insert_code' ), 999 );
+		add_action( 'wp_enqueue_scripts', array( $this, 'insert_code' ), 999 );
 		add_action( 'wp_footer', array( $this, 'jetpack_wga_classic_track_add_to_cart' ) );
 	}
 
@@ -176,10 +176,11 @@ class Jetpack_Google_Analytics_Legacy {
 				),
 			);
 		}
-		// phpcs:disable WordPress.WP.EnqueuedResources.NonEnqueuedScript
+		
+		wp_enqueue_script( 'jetpack-google-analytics', "https://www.googletagmanager.com/gtag/js?id={$tracking_id}", array(), null, array( 'strategy' => 'async' ) );
+		
 		?>
-		<!-- Jetpack Google Analytics -->
-		<script async src='https://www.googletagmanager.com/gtag/js?id=<?php echo esc_attr( $tracking_id ); ?>'></script>
+		ob_start();
 		<script>
 			window.dataLayer = window.dataLayer || [];
 			function gtag() { dataLayer.push( arguments ); }
@@ -194,9 +195,13 @@ class Jetpack_Google_Analytics_Legacy {
 			}
 			?>
 		</script>
-		<!-- End Jetpack Google Analytics -->
 		<?php
-		// phpcs:enable
+		$data_later_js = str_replace( array( '<script>', '</script>' ), '', ob_get_clean() );
+		wp_add_inline_script( 
+			'jetpack-google-analytics',
+			$data_later_js,
+			'after'
+		);
 	}
 
 	/**


### PR DESCRIPTION
This is a POC for how Jetpack's Google Analytics module could use the async script strategy (see [Core-12009](https://core.trac.wordpress.org/ticket/12009) and https://github.com/WordPress/wordpress-develop/pull/4391) instead of manually printing the async script at `wp_head`.

Without the changes here, to remove the script a plugin would have to somehow find the instance of `Jetpack_Google_Analytics_Legacy` and then do:

```php
remove_action( 'wp_head', array( $instance, 'insert_code' ), 999 );
```

This is a challenge because the `$instance` is [not a public variable](https://github.com/westonruter/jetpack/blob/379a9388b7280aeef779f3e2992f7b7170f16613/modules/google-analytics/wp-google-analytics.php#L58). They'd also have to look up the priority (here 999) and hope that Jetpack doesn't change the priority later.

Otherwise, if this could use the script loader API, a plugin wanting to remove this script would only have to do:

```php
wp_dequeue_script( 'jetpack-google-analytics' );
```

This also means that the `WordPress.WP.EnqueuedResources.NonEnqueuedScript` sniff no longer has to be suppressed in PHPCS.

Additionally, if they wanted to attach additional data to the script, all they would have to do:

```php
wp_add_inline_script( 
    'jetpack-google-analytics',
    sprintf( 
        'window.dataLayer.push( %s )', 
        wp_json_encode( array( $key, $value ) ) 
    ),
    'after'
);
```

Since the async script loading strategy proposes running inline after scripts only once the corresponding script has loaded, there is no need for code which before was required to account for the unpredictable loading order of the async script:

```diff
- window.dataLayer = window.dataLayer || []
```